### PR TITLE
refactor: stop using ActiveSupport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'pry', '~> 0.14.1'
 gem 'rake', ['>= 12.3.3', '~> 13.0']
 gem 'rspec', '~> 3'
 gem 'rubocop', '< 1.24'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '~> 0.18'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8'
 
-  s.add_runtime_dependency 'activesupport', '>= 4.1.11', '< 7.0'
   s.add_runtime_dependency 'rack', '>= 2.1.4', '< 2.3.0'
 
   s.files = `git ls-files`.split "\n"

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -71,7 +71,7 @@ class GoogleMapsGeocoder
     @json = address.is_a?(String) ? google_maps_response(address) : address
     status = @json && @json[:status]
     raise RuntimeError if status == 'OVER_QUERY_LIMIT'
-    raise GeocodingError, @json if !@json || (@json && @json.empty?) || status != 'OK'
+    raise GeocodingError, @json if !@json || @json.empty? || status != 'OK'
 
     set_attributes_from_json
     Logger.new($stderr).info('GoogleMapsGeocoder') do

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -69,7 +69,7 @@ class GoogleMapsGeocoder
   #   chez_barack = GoogleMapsGeocoder.new '1600 Pennsylvania DC'
   def initialize(address)
     @json = address.is_a?(String) ? google_maps_response(address) : address
-    status = @json && @json['status']
+    status = @json && @json[:status]
     raise RuntimeError if status == 'OVER_QUERY_LIMIT'
     raise GeocodingError, @json if !@json || (@json && @json.empty?) || status != 'OK'
 
@@ -101,7 +101,7 @@ class GoogleMapsGeocoder
   #   GoogleMapsGeocoder.new('1600 Pennsylvania DC').partial_match?
   #     => true
   def partial_match?
-    @json['results'][0]['partial_match'] == true
+    @json[:results][0][:partial_match] == true
   end
 
   # A geocoding error returned by Google Maps.
@@ -122,10 +122,10 @@ class GoogleMapsGeocoder
     # @return [GeocodingError] the geocoding error
     def initialize(json = {})
       @json = json
-      if (message = @json['error_message'])
+      if (message = @json[:error_message])
         Logger.new($stderr).error(message)
       end
-      super @json['status']
+      super @json[:status]
     end
   end
 
@@ -149,9 +149,9 @@ class GoogleMapsGeocoder
     http
   end
 
-  def parse_address_component_type(type, name = 'long_name')
-    address_component = @json['results'][0]['address_components'].detect do |ac|
-      ac['types']&.include?(type)
+  def parse_address_component_type(type, name = :long_name)
+    address_component = @json[:results][0][:address_components].detect do |ac|
+      ac[:types]&.include?(type)
     end
     address_component && address_component[name]
   end
@@ -166,7 +166,7 @@ class GoogleMapsGeocoder
   end
 
   def parse_country_short_name
-    parse_address_component_type('country', 'short_name')
+    parse_address_component_type('country', :short_name)
   end
 
   def parse_county
@@ -174,7 +174,7 @@ class GoogleMapsGeocoder
   end
 
   def parse_formatted_address
-    @json['results'][0]['formatted_address']
+    @json[:results][0][:formatted_address]
   end
 
   def parse_formatted_street_address
@@ -183,11 +183,11 @@ class GoogleMapsGeocoder
   end
 
   def parse_lat
-    @json['results'][0]['geometry']['location']['lat']
+    @json[:results][0][:geometry][:location][:lat]
   end
 
   def parse_lng
-    @json['results'][0]['geometry']['location']['lng']
+    @json[:results][0][:geometry][:location][:lng]
   end
 
   def parse_postal_code
@@ -199,7 +199,7 @@ class GoogleMapsGeocoder
   end
 
   def parse_state_short_name
-    parse_address_component_type('administrative_area_level_1', 'short_name')
+    parse_address_component_type('administrative_area_level_1', :short_name)
   end
 
   def set_attributes_from_json

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -69,7 +69,7 @@ class GoogleMapsGeocoder
   #   chez_barack = GoogleMapsGeocoder.new '1600 Pennsylvania DC'
   def initialize(address)
     @json = address.is_a?(String) ? google_maps_response(address) : address
-    status = @json && @json[:status]
+    status = @json && @json['status']
     raise RuntimeError if status == 'OVER_QUERY_LIMIT'
     raise GeocodingError, @json if !@json || @json.empty? || status != 'OK'
 
@@ -101,7 +101,7 @@ class GoogleMapsGeocoder
   #   GoogleMapsGeocoder.new('1600 Pennsylvania DC').partial_match?
   #     => true
   def partial_match?
-    @json[:results][0][:partial_match] == true
+    @json['results'][0]['partial_match'] == true
   end
 
   # A geocoding error returned by Google Maps.
@@ -122,10 +122,10 @@ class GoogleMapsGeocoder
     # @return [GeocodingError] the geocoding error
     def initialize(json = {})
       @json = json
-      if (message = @json[:error_message])
+      if (message = @json['error_message'])
         Logger.new($stderr).error(message)
       end
-      super @json[:status]
+      super @json['status']
     end
   end
 
@@ -139,7 +139,7 @@ class GoogleMapsGeocoder
   def google_maps_response(address)
     uri = URI.parse google_maps_request(address)
     response = http(uri).request(Net::HTTP::Get.new(uri.request_uri))
-    JSON.parse(response.body, symbolize_names: true)
+    JSON.parse response.body
   end
 
   def http(uri)
@@ -149,9 +149,9 @@ class GoogleMapsGeocoder
     http
   end
 
-  def parse_address_component_type(type, name = :long_name)
-    address_component = @json[:results][0][:address_components].detect do |ac|
-      ac[:types]&.include?(type)
+  def parse_address_component_type(type, name = 'long_name')
+    address_component = @json['results'][0]['address_components'].detect do |ac|
+      ac['types']&.include?(type)
     end
     address_component && address_component[name]
   end
@@ -166,7 +166,7 @@ class GoogleMapsGeocoder
   end
 
   def parse_country_short_name
-    parse_address_component_type('country', :short_name)
+    parse_address_component_type('country', 'short_name')
   end
 
   def parse_county
@@ -174,7 +174,7 @@ class GoogleMapsGeocoder
   end
 
   def parse_formatted_address
-    @json[:results][0][:formatted_address]
+    @json['results'][0]['formatted_address']
   end
 
   def parse_formatted_street_address
@@ -183,11 +183,11 @@ class GoogleMapsGeocoder
   end
 
   def parse_lat
-    @json[:results][0][:geometry][:location][:lat]
+    @json['results'][0]['geometry']['location']['lat']
   end
 
   def parse_lng
-    @json[:results][0][:geometry][:location][:lng]
+    @json['results'][0]['geometry']['location']['lng']
   end
 
   def parse_postal_code
@@ -199,7 +199,7 @@ class GoogleMapsGeocoder
   end
 
   def parse_state_short_name
-    parse_address_component_type('administrative_area_level_1', :short_name)
+    parse_address_component_type('administrative_area_level_1', 'short_name')
   end
 
   def set_attributes_from_json

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # frozen_string_literal: true
 
-require 'active_support'
+require 'json'
 require 'logger'
 require 'net/http'
 require 'rack'
@@ -71,7 +71,7 @@ class GoogleMapsGeocoder
     @json = address.is_a?(String) ? google_maps_response(address) : address
     status = @json && @json['status']
     raise RuntimeError if status == 'OVER_QUERY_LIMIT'
-    raise GeocodingError, @json if @json.blank? || status != 'OK'
+    raise GeocodingError, @json if !@json || (@json && @json.empty?) || status != 'OK'
 
     set_attributes_from_json
     Logger.new($stderr).info('GoogleMapsGeocoder') do
@@ -139,7 +139,7 @@ class GoogleMapsGeocoder
   def google_maps_response(address)
     uri = URI.parse google_maps_request(address)
     response = http(uri).request(Net::HTTP::Get.new(uri.request_uri))
-    ActiveSupport::JSON.decode response.body
+    JSON.parse(response.body, symbolize_names: true)
   end
 
   def http(uri)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'pry'
 require 'simplecov'
 require 'rubygems'
 require 'bundler'


### PR DESCRIPTION
Closes: n/a

# Goal

In order to have an even smaller dependency surface, let's remove the ActiveSupport library.


# Approach
1. Remove the gem dependency.
2. Replace `ActiveSupport::JSON.decode` with `JSON.parse`.
3. Add `pry` to facilitate debugging.
