### PR TITLE
CI: run CI on PRs only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 # Download the latest Ruby patch versions, install dependencies, and run tests.
 name: test
 on:
-  push:
+  pull_request:
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 # Download the latest Ruby patch versions, install dependencies, and run tests.
 name: test
 on:
-  pull_request:
   push:
     paths-ignore:
       - '**.md'

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -56,7 +56,7 @@ describe GoogleMapsGeocoder do
         it { expect(subject.latitude).to eq subject.lat }
         it { expect(subject.longitude).to eq subject.lng }
         it { expect(subject.state).to eq subject.state_long_name }
-        it { expect(subject.state_code).to eq subject.state_short_name }
+        it { expect(subject.state_code).to eq nil }
       end
     end
     context 'when API key is invalid' do

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -56,7 +56,7 @@ describe GoogleMapsGeocoder do
         it { expect(subject.latitude).to eq subject.lat }
         it { expect(subject.longitude).to eq subject.lng }
         it { expect(subject.state).to eq subject.state_long_name }
-        it { expect(subject.state_code).to eq nil }
+        it { expect(subject.state_code).to eq subject.state_short_name }
       end
     end
     context 'when API key is invalid' do


### PR DESCRIPTION
Closes: n/a

# Goal
Run CI on PRs only instead of pushes so fork PRs can be tested too, but without this redundancy:

![duplicate-checks](https://user-images.githubusercontent.com/113809/142367876-967f5a2f-c77e-441a-a091-eb925e2de356.png)

# Approach
(self-explanatory)

Signed-off-by: Roderick Monje <rod@foveacentral.com>
