### PR TITLE
conf: code-climate coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@
 name: test
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
   push:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
         GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       run: bundle exec rake
     - name: Code Climate coverage
+      env:
+        GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
       uses: FoveaCentral/codeclimate-test-reporter@v1
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,9 @@ jobs:
         GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       run: bundle exec rake
     - name: Code Climate coverage
-      uses: aktions/codeclimate-test-reporter@v1
+      uses: FoveaCentral/codeclimate-test-reporter@v1
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
         command: after-build --coverage-input-type lcov
-        ref: ${{ github.event.pull_request.head.sha }}
     - name: Rubocop
       run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@
 name: test
 on:
   pull_request:
-    branches:
-      - master
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -32,9 +30,7 @@ jobs:
         GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       run: bundle exec rake
     - name: Code Climate coverage
-      env:
-        GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
-      uses: FoveaCentral/codeclimate-test-reporter@v1
+      uses: aktions/codeclimate-test-reporter@v1
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
         command: after-build --coverage-input-type lcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,6 @@ jobs:
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
         command: after-build --coverage-input-type lcov
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Rubocop
       run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,11 @@ jobs:
       env:
         GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       run: bundle exec rake
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Code Climate coverage
+    - uses: paambaati/codeclimate-action@v2.2.4
+      env:
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+#      with:
+#        coverageCommand: yarn coverage
     - name: Rubocop
       run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,12 @@
 name: test
 on:
   pull_request:
+    branches:
+      - master
     paths-ignore:
       - '**.md'
       - '**.txt'
   push:
-    branches:
-      - master
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       run: bundle exec rake
     - name: Code Climate coverage
-    - uses: paambaati/codeclimate-action@v2.2.4
+      uses: paambaati/codeclimate-action@v2.2.4
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
 #      with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,6 @@ jobs:
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
         command: after-build --coverage-input-type lcov
+        GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Rubocop
       run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,5 @@ jobs:
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
         command: after-build --coverage-input-type lcov
-        GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Rubocop
       run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,6 @@ jobs:
       uses: aktions/codeclimate-test-reporter@v1
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
-        command: after-build
+        command: after-build --coverage-input-type lcov
     - name: Rubocop
       run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,9 @@ jobs:
         GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       run: bundle exec rake
     - name: Code Climate coverage
-      uses: paambaati/codeclimate-action@v2.2.4
-      env:
-        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-#      with:
-#        coverageCommand: yarn coverage
+      uses: aktions/codeclimate-test-reporter@v1
+      with:
+        codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
+        command: after-build
     - name: Rubocop
       run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - '**.md'
       - '**.txt'
   push:
+    branches:
+      - master
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 # Download the latest Ruby patch versions, install dependencies, and run tests.
 name: test
 on:
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
   push:
     paths-ignore:
       - '**.md'


### PR DESCRIPTION
Closes: #87

# Goal
Fix coverage metrics by migrating to Code Climate.

# Approach
1. Adapt [GitHub's example](https://github.com/marketplace/actions/code-climate-test-reporter).
2. Remove `pull_request` run to avoid [duplication](https://github.com/FoveaCentral/google_maps_geocoder/pull/85).

Signed-off-by: Roderick Monje <rod@foveacentral.com>
