### PR TITLE
Experimental: CI runs on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,6 @@ on:
     paths-ignore:
       - '**.md'
       - '**.txt'
-  push:
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
 jobs:
   test:
     environment: staging

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 # Download the latest Ruby patch versions, install dependencies, and run tests.
 name: test
 on:
+  pull_request:
   push:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       run: bundle exec rake
     - name: Code Climate coverage
       uses: aktions/codeclimate-test-reporter@v1
-        if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name != 'pull_request' }}
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
         command: after-build --coverage-input-type lcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,9 @@ jobs:
       run: bundle exec rake
     - name: Code Climate coverage
       uses: aktions/codeclimate-test-reporter@v1
+        if: ${{ github.event_name != 'pull_request' }}
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
         command: after-build --coverage-input-type lcov
-        if: ${{ github.event_name != 'pull_request' }}
     - name: Rubocop
       run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,6 @@ jobs:
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
         command: after-build --coverage-input-type lcov
+        if: ${{ github.event_name != 'pull_request' }}
     - name: Rubocop
       run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
 # Download the latest Ruby patch versions, install dependencies, and run tests.
 name: test
 on:
+  paths-ignore:
+    - '**.md'
+    - '**.txt'
   pull_request:
   push:
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
 jobs:
   test:
     environment: staging

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,14 @@
 # Download the latest Ruby patch versions, install dependencies, and run tests.
 name: test
 on:
-  paths-ignore:
-    - '**.md'
-    - '**.txt'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
   push:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
 jobs:
   test:
     environment: staging


### PR DESCRIPTION
Re: #85, #87, #88 

# Goal
If running CI on`pull_request` is better than the more general `push`, this is the only way it works with the `after_build` that test coverage requires.

# Approach
1. Replace `push` with `pull_request`.
2. Skip coverage run on pull-request runs.

# Notes
https://github.com/marketplace/actions/setup-code-climate

Signed-off-by: Roderick Monje <rod@foveacentral.com>
