### PR TITLE
CI: restore Coveralls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ jobs:
       env:
         GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       run: bundle exec rake
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Code Climate coverage
       uses: aktions/codeclimate-test-reporter@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,14 @@ jobs:
       env:
         GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       run: bundle exec rake
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Code Climate coverage
       uses: aktions/codeclimate-test-reporter@v1
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
         command: after-build --coverage-input-type lcov
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Rubocop
       run: bundle exec rubocop

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build status](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/workflows/test/badge.svg)](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/actions/workflows/test.yml)
 [![Code Climate](https://codeclimate.com/github/GoogleMapsGeocoder/google_maps_geocoder.svg)](https://codeclimate.com/github/GoogleMapsGeocoder/google_maps_geocoder)
+[![Coverage Status](https://coveralls.io/repos/github/GoogleMapsGeocoder/google_maps_geocoder/badge.svg?branch=master)](https://coveralls.io/github/GoogleMapsGeocoder/google_maps_geocoder?branch=master)
 [![Inline docs](https://inch-ci.org/github/Ivanoblomov/google_maps_geocoder.svg?branch=master)](https://inch-ci.org/github/Ivanoblomov/google_maps_geocoder)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/92/badge)](https://bestpractices.coreinfrastructure.org/projects/92)
 [![Gem Version](https://badge.fury.io/rb/google_maps_geocoder.svg)](https://rubygems.org/gems/google_maps_geocoder)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/workflows/test/badge.svg)](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/actions/workflows/test.yml)
 [![Code Climate](https://codeclimate.com/github/GoogleMapsGeocoder/google_maps_geocoder.svg)](https://codeclimate.com/github/GoogleMapsGeocoder/google_maps_geocoder)
-[![Coverage Status](https://coveralls.io/repos/github/GoogleMapsGeocoder/google_maps_geocoder/badge.svg?branch=master)](https://coveralls.io/github/GoogleMapsGeocoder/google_maps_geocoder?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/FoveaCentral/google_maps_geocoder/badge.svg?branch=master)](https://coveralls.io/github/FoveaCentral/google_maps_geocoder?branch=master)
 [![Inline docs](https://inch-ci.org/github/Ivanoblomov/google_maps_geocoder.svg?branch=master)](https://inch-ci.org/github/Ivanoblomov/google_maps_geocoder)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/92/badge)](https://bestpractices.coreinfrastructure.org/projects/92)
 [![Gem Version](https://badge.fury.io/rb/google_maps_geocoder.svg)](https://rubygems.org/gems/google_maps_geocoder)


### PR DESCRIPTION
Re: #87

# Goal
Restore Coveralls in case Code Climate's coverage may not generate failures. Both are merely processing results from the save SimpleCov run anyway.

# Approach
1. Add Coveralls step.
2. Add badge.
3. [Delete and re-add repo](https://coveralls.io/github/FoveaCentral/google_maps_geocoder/settings) in Coveralls to clear any invalid state.
4. Merge to master to confirm results since other branches behave strangely.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
