### PR TITLE
spec: silence output

### DIFF
--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -4,10 +4,10 @@
 
 require "#{File.dirname(__FILE__)}/../spec_helper"
 # rubocop:disable Metrics/BlockLength
-describe GoogleMapsGeocoder do
+RSpec.describe GoogleMapsGeocoder, silence_logger: true do
   describe '#new' do
     context 'with "White House"' do
-      subject do
+      subject(:geocoder) do
         GoogleMapsGeocoder.new('White House')
       rescue SocketError
         pending 'waiting for a network connection'
@@ -15,55 +15,61 @@ describe GoogleMapsGeocoder do
         pending 'waiting for query limit to pass'
       end
 
-      it(silence_logger: false) { should be_exact_match }
+      it("should be an exact match", silence_logger: false) {
+        allow_any_instance_of(Logger).to receive(:info).and_yield(nil) # to attempt to get coverage
+        should be_exact_match
+      }
 
       context 'address' do
         it do
-          expect(subject.formatted_street_address)
+          expect(geocoder.formatted_street_address)
             .to eq '1600 Pennsylvania Avenue Northwest'
         end
-        it { expect(subject.city).to eq 'Washington' }
-        it { expect(subject.state_long_name).to eq 'District of Columbia' }
-        it { expect(subject.state_short_name).to eq 'DC' }
-        it { expect(subject.postal_code).to eq '20500' }
-        it { expect(subject.country_short_name).to eq 'US' }
-        it { expect(subject.country_long_name).to eq 'United States' }
+        it { expect(geocoder.city).to eq 'Washington' }
+        it { expect(geocoder.state_long_name).to eq 'District of Columbia' }
+        it { expect(geocoder.state_short_name).to eq 'DC' }
+        it { expect(geocoder.postal_code).to eq '20500' }
+        it { expect(geocoder.country_short_name).to eq 'US' }
+        it { expect(geocoder.country_long_name).to eq 'United States' }
         it do
-          expect(subject.formatted_address)
+          expect(geocoder.formatted_address)
             .to match(/1600 Pennsylvania Avenue NW, Washington, DC 20500, USA/)
         end
       end
+
       context 'coordinates' do
-        it { expect(subject.lat).to be_within(0.005).of(38.8976633) }
-        it { expect(subject.lng).to be_within(0.005).of(-77.0365739) }
+        it { expect(geocoder.lat).to be_within(0.005).of(38.8976633) }
+        it { expect(geocoder.lng).to be_within(0.005).of(-77.0365739) }
       end
+
       context 'Geocoder API' do
-        it { expect(subject.address).to eq subject.formatted_address }
-        it { expect(subject.coordinates).to eq [subject.lat, subject.lng] }
-        it { expect(subject.country).to eq subject.country_long_name }
-        it { expect(subject.country_code).to eq subject.country_short_name }
-        it { expect(subject.latitude).to eq subject.lat }
-        it { expect(subject.longitude).to eq subject.lng }
-        it { expect(subject.state).to eq subject.state_long_name }
-        it { expect(subject.state_code).to eq subject.state_short_name }
+        it { expect(geocoder.address).to eq subject.formatted_address }
+        it { expect(geocoder.coordinates).to eq [subject.lat, subject.lng] }
+        it { expect(geocoder.country).to eq subject.country_long_name }
+        it { expect(geocoder.country_code).to eq subject.country_short_name }
+        it { expect(geocoder.latitude).to eq subject.lat }
+        it { expect(geocoder.longitude).to eq subject.lng }
+        it { expect(geocoder.state).to eq subject.state_long_name }
+        it { expect(geocoder.state_code).to eq subject.state_short_name }
       end
     end
+
     context 'when API key is invalid' do
-      before do
-        @key = ENV['GOOGLE_MAPS_API_KEY']
+      around do |example|
+        original_key = ENV['GOOGLE_MAPS_API_KEY']
         ENV['GOOGLE_MAPS_API_KEY'] = 'invalid_key'
+        example.run
+        ENV['GOOGLE_MAPS_API_KEY'] = original_key
       end
 
-      after { ENV['GOOGLE_MAPS_API_KEY'] = @key }
-
-      subject do
+      subject(:geocoder) do
         GoogleMapsGeocoder.new('nowhere that comes to mind')
       rescue SocketError
         pending 'waiting for a network connection'
       end
 
       it do
-        expect { subject }.to raise_error GoogleMapsGeocoder::GeocodingError,
+        expect { geocoder }.to raise_error GoogleMapsGeocoder::GeocodingError,
                                           'REQUEST_DENIED'
       end
     end

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -15,9 +15,7 @@ describe GoogleMapsGeocoder do
       @query_limit = true
     end
     # rubocop:enable Lint/RedundantCopDisableDirective, Style/RedundantBegin
-  end
 
-  before(:each) do
     pending 'waiting for a network connection' if @no_network
     pending 'waiting for query limit to pass' if @query_limit
   end

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -5,27 +5,21 @@
 require "#{File.dirname(__FILE__)}/../spec_helper"
 # rubocop:disable Metrics/BlockLength
 describe GoogleMapsGeocoder do
-  before(:context) do
-    # rubocop:disable Lint/RedundantCopDisableDirective, Style/RedundantBegin
-    begin
-      @exact_match = GoogleMapsGeocoder.new('White House')
-    rescue SocketError
-      @no_network  = true
-    rescue RuntimeError
-      @query_limit = true
-    end
-    # rubocop:enable Lint/RedundantCopDisableDirective, Style/RedundantBegin
-  end
-
-  before(:each) do
-    pending 'waiting for a network connection' if @no_network
-    pending 'waiting for query limit to pass' if @query_limit
+  subject do
+    GoogleMapsGeocoder.new('White House')
+  rescue SocketError
+    @no_network  = true
+  rescue RuntimeError
+    @query_limit = true
   end
 
   describe '#new' do
-    context 'with "White House"' do
-      subject { @exact_match }
+    before(:context) do
+      pending 'waiting for a network connection' if @no_network
+      pending 'waiting for query limit to pass' if @query_limit
+    end
 
+    context 'with "White House"' do
       it { should be_exact_match }
 
       context 'address' do

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -4,7 +4,7 @@
 
 require "#{File.dirname(__FILE__)}/../spec_helper"
 # rubocop:disable Metrics/BlockLength
-RSpec.describe GoogleMapsGeocoder, silence_logger: true do
+RSpec.describe GoogleMapsGeocoder do
   describe '#new' do
     context 'with "White House"' do
       subject(:geocoder) do
@@ -15,11 +15,7 @@ RSpec.describe GoogleMapsGeocoder, silence_logger: true do
         pending 'waiting for query limit to pass'
       end
 
-      it('should be an exact match', silence_logger: false) {
-        a_quiet_logger = Logger.new(IO::NULL)
-        allow(Logger).to receive(:new).and_return(a_quiet_logger)
-        should be_exact_match
-      }
+      it('should be an exact match') { should be_exact_match }
 
       context 'address' do
         it do

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe GoogleMapsGeocoder, silence_logger: true do
         pending 'waiting for query limit to pass'
       end
 
-      it("should be an exact match", silence_logger: false) {
+      it('should be an exact match', silence_logger: false) {
         a_quiet_logger = Logger.new(IO::NULL)
         allow(Logger).to receive(:new).and_return(a_quiet_logger)
         should be_exact_match
@@ -71,7 +71,7 @@ RSpec.describe GoogleMapsGeocoder, silence_logger: true do
 
       it do
         expect { geocoder }.to raise_error GoogleMapsGeocoder::GeocodingError,
-                                          'REQUEST_DENIED'
+                                           'REQUEST_DENIED'
       end
     end
   end

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -15,7 +15,7 @@ describe GoogleMapsGeocoder do
         pending 'waiting for query limit to pass'
       end
 
-      it { should be_exact_match }
+      it(silence_logger: false) { should be_exact_match }
 
       context 'address' do
         it do

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe GoogleMapsGeocoder, silence_logger: true do
 
       it("should be an exact match", silence_logger: false) {
         a_quiet_logger = Logger.new(IO::NULL)
-        allow_any_instance_of(Logger).to receive(:info).and_yield(a_quiet_logger) # to attempt to get coverage
+        allow(Logger).to receive(:new).and_return(a_quiet_logger)
         should be_exact_match
       }
 

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -5,24 +5,15 @@
 require "#{File.dirname(__FILE__)}/../spec_helper"
 # rubocop:disable Metrics/BlockLength
 describe GoogleMapsGeocoder do
-  before(:example) do
-    # rubocop:disable Lint/RedundantCopDisableDirective, Style/RedundantBegin
-    begin
-      @exact_match = GoogleMapsGeocoder.new('White House')
-    rescue SocketError
-      @no_network  = true
-    rescue RuntimeError
-      @query_limit = true
-    end
-    # rubocop:enable Lint/RedundantCopDisableDirective, Style/RedundantBegin
-
-    pending 'waiting for a network connection' if @no_network
-    pending 'waiting for query limit to pass' if @query_limit
-  end
-
   describe '#new' do
     context 'with "White House"' do
-      subject { @exact_match }
+      subject do
+        GoogleMapsGeocoder.new('White House')
+      rescue SocketError
+        pending 'waiting for a network connection'
+      rescue GoogleMapsGeocoder::GeocodingError
+        pending 'waiting for query limit to pass'
+      end
 
       it { should be_exact_match }
 
@@ -65,7 +56,11 @@ describe GoogleMapsGeocoder do
 
       after { ENV['GOOGLE_MAPS_API_KEY'] = @key }
 
-      subject { GoogleMapsGeocoder.new('nowhere that comes to mind') }
+      subject do
+        GoogleMapsGeocoder.new('nowhere that comes to mind')
+      rescue SocketError
+        pending 'waiting for a network connection'
+      end
 
       it do
         expect { subject }.to raise_error GoogleMapsGeocoder::GeocodingError,

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -5,7 +5,7 @@
 require "#{File.dirname(__FILE__)}/../spec_helper"
 # rubocop:disable Metrics/BlockLength
 describe GoogleMapsGeocoder do
-  before(:all) do
+  before(:context) do
     # rubocop:disable Lint/RedundantCopDisableDirective, Style/RedundantBegin
     begin
       @exact_match = GoogleMapsGeocoder.new('White House')

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -5,21 +5,27 @@
 require "#{File.dirname(__FILE__)}/../spec_helper"
 # rubocop:disable Metrics/BlockLength
 describe GoogleMapsGeocoder do
-  subject do
-    GoogleMapsGeocoder.new('White House')
-  rescue SocketError
-    @no_network  = true
-  rescue RuntimeError
-    @query_limit = true
+  before(:example) do
+    # rubocop:disable Lint/RedundantCopDisableDirective, Style/RedundantBegin
+    begin
+      @exact_match = GoogleMapsGeocoder.new('White House')
+    rescue SocketError
+      @no_network  = true
+    rescue RuntimeError
+      @query_limit = true
+    end
+    # rubocop:enable Lint/RedundantCopDisableDirective, Style/RedundantBegin
+  end
+
+  before(:each) do
+    pending 'waiting for a network connection' if @no_network
+    pending 'waiting for query limit to pass' if @query_limit
   end
 
   describe '#new' do
-    before(:context) do
-      pending 'waiting for a network connection' if @no_network
-      pending 'waiting for query limit to pass' if @query_limit
-    end
-
     context 'with "White House"' do
+      subject { @exact_match }
+
       it { should be_exact_match }
 
       context 'address' do

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe GoogleMapsGeocoder, silence_logger: true do
       end
 
       it("should be an exact match", silence_logger: false) {
-        allow_any_instance_of(Logger).to receive(:info).and_yield(nil) # to attempt to get coverage
+        a_quiet_logger = Logger.new(IO::NULL)
+        allow_any_instance_of(Logger).to receive(:info).and_yield(a_quiet_logger) # to attempt to get coverage
         should be_exact_match
       }
 

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe GoogleMapsGeocoder do
         pending 'waiting for query limit to pass'
       end
 
-      it('should be an exact match') { should be_exact_match }
+      it { should be_exact_match }
 
       context 'address' do
         it do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,10 +15,15 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'google_maps_geocoder/google_maps_geocoder'
 # silence output
 RSpec.configure do |config|
+  original_stderr = $stderr
+  original_stdout = $stdout
   config.before(:context) do
-    allow_any_instance_of(Logger).to receive(anything).and_return true
+    # Redirect stderr and stdout
+    $stderr = File.open(File::NULL, 'w')
+    $stdout = File.open(File::NULL, 'w')
   end
   config.after(:context) do
-    allow_any_instance_of(Logger).to receive.and_call_original
+    $stderr = original_stderr
+    $stdout = original_stdout
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,12 +17,12 @@ require 'google_maps_geocoder/google_maps_geocoder'
 RSpec.configure do |config|
   original_stderr = $stderr
   original_stdout = $stdout
-  config.before(:all) do
+  config.before(:context) do
     # Redirect stderr and stdout
     $stderr = File.open(File::NULL, 'w')
     $stdout = File.open(File::NULL, 'w')
   end
-  config.after(:all) do
+  config.after(:context) do
     $stderr = original_stderr
     $stdout = original_stdout
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,9 +15,11 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'google_maps_geocoder/google_maps_geocoder'
 # silence output
 RSpec.configure do |config|
-  config.before(:example, silence_logger: true) do
-    allow_any_instance_of(Logger).to receive(:info).and_return true
-    allow_any_instance_of(Logger).to receive(:error).and_return true
+  config.before(:example, silence_logger = true) do
+    if silence_logger
+      allow_any_instance_of(Logger).to receive(:info).and_return true
+      allow_any_instance_of(Logger).to receive(:error).and_return true
+    end
   end
 
   config.after(:example) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,9 +15,11 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'google_maps_geocoder/google_maps_geocoder'
 # silence output
 RSpec.configure do |config|
-  config.before(:example) do
-    allow_any_instance_of(Logger).to receive(:info).and_return true
-    allow_any_instance_of(Logger).to receive(:error).and_return true
+  config.before(:example, silence_logger = true) do
+    if silence_logger
+      allow_any_instance_of(Logger).to receive(:info).and_return true
+      allow_any_instance_of(Logger).to receive(:error).and_return true
+    end
   end
   config.after(:example) do
     allow_any_instance_of(Logger).to receive(:info).and_call_original

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,13 +15,12 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'google_maps_geocoder/google_maps_geocoder'
 # silence output
 RSpec.configure do |config|
-  config.before(:example, silence_logger = true) do
-    if silence_logger
-      allow_any_instance_of(Logger).to receive(:info).and_return true
-      allow_any_instance_of(Logger).to receive(:error).and_return true
-    end
+  config.before(:example, silence_logger: true) do
+    allow_any_instance_of(Logger).to receive(:info).and_return true
+    allow_any_instance_of(Logger).to receive(:error).and_return true
   end
-  config.after(:example) do
+
+  config.after(:example, silence_logger: true) do
     allow_any_instance_of(Logger).to receive(:info).and_call_original
     allow_any_instance_of(Logger).to receive(:error).and_call_original
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,17 @@ end
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'google_maps_geocoder/google_maps_geocoder'
+# silence output
+RSpec.configure do |config|
+  original_stderr = $stderr
+  original_stdout = $stdout
+  config.before(:all) do
+    # Redirect stderr and stdout
+    $stderr = File.open(File::NULL, 'w')
+    $stdout = File.open(File::NULL, 'w')
+  end
+  config.after(:all) do
+    $stderr = original_stderr
+    $stdout = original_stdout
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ RSpec.configure do |config|
     allow_any_instance_of(Logger).to receive(:error).and_return true
   end
 
-  config.after(:example, silence_logger: true) do
+  config.after(:example) do
     allow_any_instance_of(Logger).to receive(:info).and_call_original
     allow_any_instance_of(Logger).to receive(:error).and_call_original
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,11 +15,9 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'google_maps_geocoder/google_maps_geocoder'
 # silence output
 RSpec.configure do |config|
-  config.before(:example, silence_logger = true) do
-    if silence_logger
-      quiet_logger = Logger.new(IO::NULL)
-      allow(Logger).to receive(:new).and_return(quiet_logger)
-    end
+  config.before(:example) do
+    quiet_logger = Logger.new(IO::NULL)
+    allow(Logger).to receive(:new).and_return(quiet_logger)
   end
 
   config.after(:example) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,15 +15,10 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'google_maps_geocoder/google_maps_geocoder'
 # silence output
 RSpec.configure do |config|
-  original_stderr = $stderr
-  original_stdout = $stdout
   config.before(:context) do
-    # Redirect stderr and stdout
-    $stderr = File.open(File::NULL, 'w')
-    $stdout = File.open(File::NULL, 'w')
+    allow_any_instance_of(Logger).to receive(anything).and_return true
   end
   config.after(:context) do
-    $stderr = original_stderr
-    $stdout = original_stdout
+    allow_any_instance_of(Logger).to receive.and_call_original
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,13 +17,12 @@ require 'google_maps_geocoder/google_maps_geocoder'
 RSpec.configure do |config|
   config.before(:example, silence_logger = true) do
     if silence_logger
-      allow_any_instance_of(Logger).to receive(:info).and_return true
-      allow_any_instance_of(Logger).to receive(:error).and_return true
+      quiet_logger = Logger.new(IO::NULL)
+      allow(Logger).to receive(:new).and_return(quiet_logger)
     end
   end
 
   config.after(:example) do
-    allow_any_instance_of(Logger).to receive(:info).and_call_original
-    allow_any_instance_of(Logger).to receive(:error).and_call_original
+    allow(Logger).to receive(:new).and_call_original
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,10 +15,12 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'google_maps_geocoder/google_maps_geocoder'
 # silence output
 RSpec.configure do |config|
-  config.before(:context) do
-    allow_any_instance_of(Logger).to receive(anything).and_return true
+  config.before(:example) do
+    allow_any_instance_of(Logger).to receive(:info).and_return true
+    allow_any_instance_of(Logger).to receive(:error).and_return true
   end
-  config.after(:context) do
-    allow_any_instance_of(Logger).to receive.and_call_original
+  config.after(:example) do
+    allow_any_instance_of(Logger).to receive(:info).and_call_original
+    allow_any_instance_of(Logger).to receive(:error).and_call_original
   end
 end


### PR DESCRIPTION
Closes: n/a

# Goal
Silence log output during tests for cleaner test results.

# Approach
1. Mock `logger` calls before each example.
2. Restore original behavior after.
3. Extract `:silence_logger` argument to silence conditionally (we lose coverage otherwise).
4. Simplify network/API error handling by consolidating logic into `subject`.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
