### PR TITLE
doc: repo links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@ For more information, see GitHub's documentation on [creating branches](https://
 
 ### How we handle proposals
 
-We use GitHub to track proposed changes via its [issue tracker](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/issues) and [pull requests](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/pulls). Specific changes are proposed using those mechanisms. Issues are assigned to an individual, who works it, and then marks it complete. If there are questions or objections, the conversation area of that issue or pull request is used to resolve it.
+We use GitHub to track proposed changes via its [issue tracker](https://github.com/FoveaCentral/google_maps_geocoder/issues) and [pull requests](https://github.com/FoveaCentral/google_maps_geocoder/pulls). Specific changes are proposed using those mechanisms. Issues are assigned to an individual, who works it, and then marks it complete. If there are questions or objections, the conversation area of that issue or pull request is used to resolve it.
 
 ### Two-person review
 
@@ -44,13 +44,13 @@ It's not practical to fix old contributions in git, so if one is forgotten, do n
 
 ### **New to open-source?**
 
-Try your hand at one of the small tasks ideal for new or casual contributors that are [up-for-grabs](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs). Welcome to the community!
+Try your hand at one of the small tasks ideal for new or casual contributors that are [up-for-grabs](https://github.com/FoveaCentral/google_maps_geocoder/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs). Welcome to the community!
 
 ### **Did you find a bug?**
 
-1. **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/issues).
+1. **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/FoveaCentral/google_maps_geocoder/issues).
 
-2. If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/issues/new/choose). Be sure to include:
+2. If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/FoveaCentral/google_maps_geocoder/issues/new/choose). Be sure to include:
     1. a **title and clear description**
     2. as much **relevant information** as possible
     3. a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
@@ -63,6 +63,6 @@ Try your hand at one of the small tasks ideal for new or casual contributors tha
 
 3. **Update the inline documentation.** Format it with [YARD](https://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md). For example, see [`GoogleMapsGeocoder.new`](../lib/google_maps_geocoder/google_maps_geocoder.rb).
 
-4. [Open a pull request](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/compare) with the patch or feature. Follow the template's directions.
+4. [Open a pull request](https://github.com/FoveaCentral/google_maps_geocoder/compare) with the patch or feature. Follow the template's directions.
 
 ## Thanks for contributing!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
-Closes: #
+# Closes: #
 
-# Goal
+## Goal
 What problem does this pull request solve? This should be close to the goal of the issue this pull request addresses.
 
-# Approach
+## Approach
 1. **Describe, in numbered steps, the approach you chose** to solve the above problem.
     1. This will help code reviewers get oriented quickly.
     2. It will also document for future maintainers exactly what changed (and why) when this PR was merged.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GoogleMapsGeocoder
 
-[![Build status](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/workflows/test/badge.svg)](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/actions/workflows/test.yml)
-[![Code Climate](https://codeclimate.com/github/GoogleMapsGeocoder/google_maps_geocoder.svg)](https://codeclimate.com/github/GoogleMapsGeocoder/google_maps_geocoder)
+[![Build status](https://github.com/FoveaCentral/google_maps_geocoder/workflows/test/badge.svg)](https://github.com/FoveaCentral/google_maps_geocoder/actions/workflows/test.yml)
+[![Code Climate](https://codeclimate.com/github/FoveaCentral/google_maps_geocoder.svg)](https://codeclimate.com/github/FoveaCentral/google_maps_geocoder)
 [![Coverage Status](https://coveralls.io/repos/github/FoveaCentral/google_maps_geocoder/badge.svg?branch=master)](https://coveralls.io/github/FoveaCentral/google_maps_geocoder?branch=master)
 [![Inline docs](https://inch-ci.org/github/Ivanoblomov/google_maps_geocoder.svg?branch=master)](https://inch-ci.org/github/Ivanoblomov/google_maps_geocoder)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/92/badge)](https://bestpractices.coreinfrastructure.org/projects/92)
@@ -34,7 +34,7 @@ A simple Plain Old Ruby Object wrapper for geocoding with Google Maps.
 `GoogleMapsGeocoder` is cryptographically signed. To insure the gem you install hasn’t been tampered with, add my public key as a trusted certificate and then install:
 
 ```sh
-gem cert --add <(curl -Ls https://raw.github.com/GoogleMapsGeocoder/google_maps_geocoder/master/certs/ivanoblomov.pem)
+gem cert --add <(curl -Ls https://raw.github.com/FoveaCentral/google_maps_geocoder/master/certs/ivanoblomov.pem)
 gem install google_maps_geocoder -P HighSecurity
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-[Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) automatically [patches known vulnerabilities](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/pulls?q=is%3Apr+is%3Aclosed+author%3Aapp%2Fdependabot).
+[Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) automatically [patches known vulnerabilities](https://github.com/FoveaCentral/google_maps_geocoder/pulls?q=is%3Apr+is%3Aclosed+author%3Aapp%2Fdependabot).
 
 | Version | Supported          |
 | ------- | ------------------ |
@@ -11,6 +11,6 @@
 
 ## Reporting a Vulnerability
 
-1. To report a security vulnerability, [open an issue](https://github.com/GoogleMapsGeocoder/google_maps_geocoder/issues/new/choose).
+1. To report a security vulnerability, [open an issue](https://github.com/FoveaCentral/google_maps_geocoder/issues/new/choose).
 2. Updates are made within 48 hours.
 3. If the vulnerability is accepted, we'll try to patch it within a week.

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.description = 'Geocode a location without worrying about parsing Google '\
                   "Maps' response. GoogleMapsGeocoder wraps it in a plain-old "\
                   'Ruby object.'
-  s.homepage = 'https://github.com/GoogleMapsGeocoder/google_maps_geocoder'
+  s.homepage = 'https://github.com/FoveaCentral/google_maps_geocoder'
   s.authors = ['Roderick Monje']
   s.cert_chain = ['certs/ivanoblomov.pem']
   s.email = 'rod@foveacentral.com'


### PR DESCRIPTION
Closes: #69

# Goal

# Approach
1. Updated repo links.

# Notes
These links became outdated because [requiring 2FA](https://bestpractices.coreinfrastructure.org/en/projects/92?criteria_level=2#changecontrol) necessitated moving the repository into an organization.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
