### PR TITLE
CI: Inch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,5 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run RuboCop
       run: bundle exec rubocop
+    - name: Run Inch
+      run: bundle exec inch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,14 @@ jobs:
       env:
         GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       run: bundle exec rake
-    - name: Code Climate coverage
+    - name: Send Code Climate coverage
       uses: aktions/codeclimate-test-reporter@v1
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
         command: after-build --coverage-input-type lcov
-    - name: Coveralls
+    - name: Send Coveralls coverage
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Rubocop
+    - name: Run RuboCop
       run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,4 @@ jobs:
     - name: Run RuboCop
       run: bundle exec rubocop
     - name: Run Inch
-      run: bundle exec inch
+      run: bundle exec inch --pedantic

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'pry', '~> 0.14.1'
+gem 'inch', '~> 0.8'
 gem 'rake', ['>= 12.3.3', '~> 13.0']
 gem 'rspec', '~> 3'
 gem 'rubocop', '< 1.24'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'inch', '~> 0.8'
+gem 'pry', '~> 0.14.1'
 gem 'rake', ['>= 12.3.3', '~> 13.0']
 gem 'rspec', '~> 3'
 gem 'rubocop', '< 1.24'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build status](https://github.com/FoveaCentral/google_maps_geocoder/workflows/test/badge.svg)](https://github.com/FoveaCentral/google_maps_geocoder/actions/workflows/test.yml)
 [![Code Climate](https://codeclimate.com/github/FoveaCentral/google_maps_geocoder.svg)](https://codeclimate.com/github/FoveaCentral/google_maps_geocoder)
 [![Coverage Status](https://coveralls.io/repos/github/FoveaCentral/google_maps_geocoder/badge.svg?branch=master)](https://coveralls.io/github/FoveaCentral/google_maps_geocoder?branch=master)
-[![Inline docs](https://inch-ci.org/github/Ivanoblomov/google_maps_geocoder.svg?branch=master)](https://inch-ci.org/github/Ivanoblomov/google_maps_geocoder)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/92/badge)](https://bestpractices.coreinfrastructure.org/projects/92)
 [![Gem Version](https://badge.fury.io/rb/google_maps_geocoder.svg)](https://rubygems.org/gems/google_maps_geocoder)
 

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -19,11 +19,13 @@ class GoogleMapsGeocoder
     city country_long_name country_short_name county lat lng postal_code
     state_long_name state_short_name
   ].freeze
+  private_constant :GOOGLE_ADDRESS_SEGMENTS
   GOOGLE_MAPS_API = 'https://maps.googleapis.com/maps/api/geocode/json'
-
+  private_constant :GOOGLE_MAPS_API
   ALL_ADDRESS_SEGMENTS = (
     GOOGLE_ADDRESS_SEGMENTS + %i[formatted_address formatted_street_address]
   ).freeze
+  private_constant :ALL_ADDRESS_SEGMENTS
 
   # Returns the complete formatted address with standardized abbreviations.
   #

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -14,6 +14,7 @@ require 'rack'
 #   chez_barack.formatted_address
 #     => "1600 Pennsylvania Avenue Northwest, President's Park,
 #         Washington, DC 20500, USA"
+# rubocop:disable Metrics/ClassLength
 class GoogleMapsGeocoder
   GOOGLE_ADDRESS_SEGMENTS = %i[
     city country_long_name country_short_name county lat lng postal_code
@@ -210,3 +211,4 @@ class GoogleMapsGeocoder
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/lib/google_maps_geocoder/version.rb
+++ b/lib/google_maps_geocoder/version.rb
@@ -2,5 +2,6 @@
 
 # A simple PORO wrapper for geocoding with Google Maps.
 class GoogleMapsGeocoder
+  # This gem's version.
   VERSION = '0.7.5' unless defined?(GoogleMapsGeocoder::VERSION)
 end


### PR DESCRIPTION
# Closes: #64

## Goal
This doesn't replace http://Inch-CI.org (since no equivalent apparently exists), but it does run `inch` on CI as part of the GitHub Action.

## Approach
1. Add `inch` to `Gemfile`.
2. Have test workflow run `inch --pedantic`.
3. Fix warnings.
4. Remove old badge.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
