### PR TITLE
CI: Keep in-support Ruby versions in matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
     name: Ruby ${{ matrix.ruby-version }}
     strategy:
       matrix:
-        ruby-version: [2.5, 2.6, 2.7, '3.0']
+        ruby-version: ['3.0', 3.1, 3.2, 3.3]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
## Goal

Keep the gem working on latest Ruby versions.

## Approach
1. Drop EOL'd Ruby versions.
2. Use latest version of a GitHub Action (to avoid deprecation warnings in CI output).
3. Add in-support Ruby versions.

Signed-off-by: Olle Jonsson <olle.jonsson@gmail.com>
