### PR TITLE
CI: Tell dependabot to update GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Goal

This PR adds a configuration to tell Dependabot to update the versions used for some well-known GitHub Actions, such as `checkout`, **in order to avoid deprecation warnings when those get too old**.

## Approach
1. Added [recommended lines](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).

Signed-off-by: Olle Jonsson <olle.jonsson@gmail.com>
