### PR TITLE
Added GitHub sponsorhip

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: ivanoblomov
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2022 Roderick Monje
+Copyright (c) 2011-2024 Roderick Monje
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
# Closes: n/a

## Goal
Allow users to sponsor via GitHub.

## Approach
1. Add username to `FUNDING.yml`.
2. _Unrelated:_ Update license copyright.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
