### PR TITLE
spec: observe RSpec style

### DIFF
--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -6,51 +6,78 @@ require "#{File.dirname(__FILE__)}/../spec_helper"
 # rubocop:disable Metrics/BlockLength
 RSpec.describe GoogleMapsGeocoder do
   describe '#new' do
-    context 'with "White House"' do
-      subject(:geocoder) do
-        GoogleMapsGeocoder.new('White House')
-      rescue SocketError
-        pending 'waiting for a network connection'
-      rescue GoogleMapsGeocoder::GeocodingError => e
-        raise if e.json['status'] == 'REQUEST_DENIED'
+    context 'when API key is valid' do
+      context 'with "White House"' do
+        subject(:geocoder) do
+          GoogleMapsGeocoder.new('White House')
+        rescue SocketError
+          pending 'waiting for a network connection'
+        rescue GoogleMapsGeocoder::GeocodingError => e
+          raise if e.json['status'] == 'REQUEST_DENIED'
 
-        pending 'waiting for query limit to pass'
-      end
-
-      it { should be_partial_match }
-      it { should_not be_exact_match }
-
-      context 'address' do
-        it do
-          expect(geocoder.formatted_street_address)
-            .to eq '1600 Pennsylvania Avenue Northwest'
+          pending 'waiting for query limit to pass'
         end
-        it { expect(geocoder.city).to eq 'Washington' }
-        it { expect(geocoder.state_long_name).to eq 'District of Columbia' }
-        it { expect(geocoder.state_short_name).to eq 'DC' }
-        it { expect(geocoder.postal_code).to eq '20500' }
-        it { expect(geocoder.country_short_name).to eq 'US' }
-        it { expect(geocoder.country_long_name).to eq 'United States' }
-        it do
-          expect(geocoder.formatted_address)
-            .to match(/1600 Pennsylvania Avenue NW, Washington, DC 20500, USA/)
+
+        it { should be_partial_match }
+        it { should_not be_exact_match }
+
+        describe '#formatted_street_address' do
+          it { expect(geocoder.formatted_street_address).to eq '1600 Pennsylvania Avenue Northwest' }
         end
-      end
+        describe '#city' do
+          it { expect(geocoder.city).to eq 'Washington' }
+        end
+        describe '#state_long_name' do
+          it { expect(geocoder.state_long_name).to eq 'District of Columbia' }
+        end
+        describe '#state_short_name' do
+          it { expect(geocoder.state_short_name).to eq 'DC' }
+        end
+        describe '#postal_code' do
+          it { expect(geocoder.postal_code).to eq '20500' }
+        end
+        describe '#country_short_name' do
+          it { expect(geocoder.country_short_name).to eq 'US' }
+        end
+        describe '#country_long_name' do
+          it { expect(geocoder.country_long_name).to eq 'United States' }
+        end
+        describe '#formatted_address' do
+          it { expect(geocoder.formatted_address).to match(/1600 Pennsylvania Avenue NW, Washington, DC 20500, USA/) }
+        end
+        describe '#lat' do
+          it { expect(geocoder.lat).to be_within(0.005).of(38.8976633) }
+        end
+        describe '#lat' do
+          it { expect(geocoder.lng).to be_within(0.005).of(-77.0365739) }
+        end
 
-      context 'coordinates' do
-        it { expect(geocoder.lat).to be_within(0.005).of(38.8976633) }
-        it { expect(geocoder.lng).to be_within(0.005).of(-77.0365739) }
-      end
-
-      context 'Geocoder API' do
-        it { expect(geocoder.address).to eq subject.formatted_address }
-        it { expect(geocoder.coordinates).to eq [subject.lat, subject.lng] }
-        it { expect(geocoder.country).to eq subject.country_long_name }
-        it { expect(geocoder.country_code).to eq subject.country_short_name }
-        it { expect(geocoder.latitude).to eq subject.lat }
-        it { expect(geocoder.longitude).to eq subject.lng }
-        it { expect(geocoder.state).to eq subject.state_long_name }
-        it { expect(geocoder.state_code).to eq subject.state_short_name }
+        context 'when using Geocoder API' do
+          describe '#address' do
+            it { expect(geocoder.address).to eq subject.formatted_address }
+          end
+          describe '#coordinates' do
+            it { expect(geocoder.coordinates).to eq [subject.lat, subject.lng] }
+          end
+          describe '#country' do
+            it { expect(geocoder.country).to eq subject.country_long_name }
+          end
+          describe '#country_code' do
+            it { expect(geocoder.country_code).to eq subject.country_short_name }
+          end
+          describe '#latitude' do
+            it { expect(geocoder.latitude).to eq subject.lat }
+          end
+          describe '#longitude' do
+            it { expect(geocoder.longitude).to eq subject.lng }
+          end
+          describe '#state' do
+            it { expect(geocoder.state).to eq subject.state_long_name }
+          end
+          describe '#state_code' do
+            it { expect(geocoder.state_code).to eq subject.state_short_name }
+          end
+        end
       end
     end
 


### PR DESCRIPTION
# Closes: n/a

## Goal
Observe conventions in [RSpec Style Guide](https://rspec.rubystyle.guide) so output reads as full sentences.

## Approach
1. Add `context` for valid API key.
2. Wrap each method test in a `describe` block.

## Results
`rspec --format d` outputs:

### Before
```ruby
GoogleMapsGeocoder
  #new
    with "White House"
      is expected to be partial match
      is expected not to be exact match
      address
        is expected to eq "1600 Pennsylvania Avenue Northwest"
        is expected to eq "Washington"
        is expected to eq "District of Columbia"
        is expected to eq "DC"
        is expected to eq "20500"
        is expected to eq "US"
        is expected to eq "United States"
        is expected to match /1600 Pennsylvania Avenue NW, Washington, DC 20500, USA/
      coordinates
        is expected to be within 0.005 of 38.8976633
        is expected to be within 0.005 of -77.0365739
      Geocoder API
        is expected to eq "1600 Pennsylvania Avenue NW, Washington, DC 20500, USA"
        is expected to eq [38.8976763, -77.0365298]
        is expected to eq "United States"
        is expected to eq "US"
        is expected to eq 38.8976763
        is expected to eq -77.0365298
        is expected to eq "District of Columbia"
        is expected to eq "DC"
    when API key is invalid
      is expected to raise GoogleMapsGeocoder::GeocodingError

Finished in 3 seconds (files took 0.14078 seconds to load)
21 examples, 0 failures
```

### After
```ruby
GoogleMapsGeocoder
  #new
    when API key is valid
      with "White House"
        is expected to be partial match
        is expected not to be exact match
        #formatted_street_address
          is expected to eq "1600 Pennsylvania Avenue Northwest"
        #city
          is expected to eq "Washington"
        #state_long_name
          is expected to eq "District of Columbia"
        #state_short_name
          is expected to eq "DC"
        #postal_code
          is expected to eq "20500"
        #country_short_name
          is expected to eq "US"
        #country_long_name
          is expected to eq "United States"
        #formatted_address
          is expected to match /1600 Pennsylvania Avenue NW, Washington, DC 20500, USA/
        #lat
          is expected to be within 0.005 of 38.8976633
        #lat
          is expected to be within 0.005 of -77.0365739
        when using Geocoder API
          #address
            is expected to eq "1600 Pennsylvania Avenue NW, Washington, DC 20500, USA"
          #coordinates
            is expected to eq [38.8976763, -77.0365298]
          #country
            is expected to eq "United States"
          #country_code
            is expected to eq "US"
          #latitude
            is expected to eq 38.8976763
          #longitude
            is expected to eq -77.0365298
          #state
            is expected to eq "District of Columbia"
          #state_code
            is expected to eq "DC"
    when API key is invalid
      is expected to raise GoogleMapsGeocoder::GeocodingError

Finished in 2.97 seconds (files took 0.141 seconds to load)
21 examples, 0 failures
```

Signed-off-by: Roderick Monje <rod@foveacentral.com>
