### PR TITLE
Enable existing Rubocop extensions; add rubocop-performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  NewCops: enable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,7 @@
+require:
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-rspec
+
 AllCops:
   NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'pry', '~> 0.14.1'
 gem 'rake', '~> 13'
 gem 'rspec', '~> 3'
 gem 'rubocop', '< 1.68'
+gem 'rubocop-performance', require: false
 gem 'rubocop-rake', '~> 0'
 gem 'rubocop-rspec', '~> 3'
 gem 'simplecov', '~> 0.18'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rake', '~> 13'
 gem 'rspec', '~> 3'
 gem 'rubocop', '< 1.68'
 gem 'rubocop-performance', require: false
-gem 'rubocop-rake', '~> 0'
-gem 'rubocop-rspec', '~> 3'
+gem 'rubocop-rake', require: false
+gem 'rubocop-rspec', require: false
 gem 'simplecov', '~> 0.18'
 gem 'simplecov-lcov', '~> 0.8'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -6,18 +6,19 @@ Gem::Specification.new do |s|
   s.version = GoogleMapsGeocoder::VERSION.dup
   s.licenses = ['MIT']
   s.summary = 'A simple PORO wrapper for geocoding with Google Maps.'
-  s.description = 'Geocode a location without worrying about parsing Google '\
-                  "Maps' response. GoogleMapsGeocoder wraps it in a plain-old "\
+  s.description = 'Geocode a location without worrying about parsing Google ' \
+                  "Maps' response. GoogleMapsGeocoder wraps it in a plain-old " \
                   'Ruby object.'
   s.homepage = 'https://github.com/FoveaCentral/google_maps_geocoder'
   s.authors = ['Roderick Monje']
   s.cert_chain = ['certs/ivanoblomov.pem']
   s.email = 'rod@foveacentral.com'
-  s.signing_key = File.expand_path('~/.ssh/gem-private_key.pem') if $PROGRAM_NAME =~ /gem\z/
+  s.signing_key = File.expand_path('~/.ssh/gem-private_key.pem') if $PROGRAM_NAME.end_with?('gem')
 
-  s.add_runtime_dependency 'rack', '>= 2.1.4', '< 3.2.0'
+  s.add_dependency 'rack', '>= 2.1.4', '< 3.2.0'
 
   s.files = `git ls-files`.split "\n"
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 3.0'
+  s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -128,15 +128,15 @@ class GoogleMapsGeocoder
       if (message = @json['error_message'])
         Logger.new($stderr).error(message)
       end
-      super @json
+      super(@json)
     end
   end
 
   private
 
   def google_maps_request(address)
-    "#{GOOGLE_MAPS_API}?address=#{Rack::Utils.escape address}"\
-    "&key=#{ENV['GOOGLE_MAPS_API_KEY']}"
+    "#{GOOGLE_MAPS_API}?address=#{Rack::Utils.escape address}" \
+      "&key=#{ENV.fetch('GOOGLE_MAPS_API_KEY', nil)}"
   end
 
   def google_maps_response(address)
@@ -181,8 +181,8 @@ class GoogleMapsGeocoder
   end
 
   def parse_formatted_street_address
-    "#{parse_address_component_type('street_number')} "\
-    "#{parse_address_component_type('route')}"
+    "#{parse_address_component_type('street_number')} " \
+      "#{parse_address_component_type('route')}"
   end
 
   def parse_lat
@@ -207,7 +207,7 @@ class GoogleMapsGeocoder
 
   def set_attributes_from_json
     ALL_ADDRESS_SEGMENTS.each do |segment|
-      instance_variable_set :"@#{segment}", send("parse_#{segment}")
+      instance_variable_set :"@#{segment}", send(:"parse_#{segment}")
     end
   end
 end

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -64,35 +64,35 @@ RSpec.describe GoogleMapsGeocoder do
 
         context 'when using Geocoder API' do
           describe '#address' do
-            it { expect(geocoder.address).to eq subject.formatted_address }
+            it { expect(geocoder.address).to eq geocoder.formatted_address }
           end
 
           describe '#coordinates' do
-            it { expect(geocoder.coordinates).to eq [subject.lat, subject.lng] }
+            it { expect(geocoder.coordinates).to eq [geocoder.lat, geocoder.lng] }
           end
 
           describe '#country' do
-            it { expect(geocoder.country).to eq subject.country_long_name }
+            it { expect(geocoder.country).to eq geocoder.country_long_name }
           end
 
           describe '#country_code' do
-            it { expect(geocoder.country_code).to eq subject.country_short_name }
+            it { expect(geocoder.country_code).to eq geocoder.country_short_name }
           end
 
           describe '#latitude' do
-            it { expect(geocoder.latitude).to eq subject.lat }
+            it { expect(geocoder.latitude).to eq geocoder.lat }
           end
 
           describe '#longitude' do
-            it { expect(geocoder.longitude).to eq subject.lng }
+            it { expect(geocoder.longitude).to eq geocoder.lng }
           end
 
           describe '#state' do
-            it { expect(geocoder.state).to eq subject.state_long_name }
+            it { expect(geocoder.state).to eq geocoder.state_long_name }
           end
 
           describe '#state_code' do
-            it { expect(geocoder.state_code).to eq subject.state_short_name }
+            it { expect(geocoder.state_code).to eq geocoder.state_short_name }
           end
         end
       end

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GoogleMapsGeocoder do
     context 'when API key is valid' do
       context 'with "White House"' do
         subject(:geocoder) do
-          GoogleMapsGeocoder.new('White House')
+          described_class.new('White House')
         rescue SocketError
           pending 'waiting for a network connection'
         rescue GoogleMapsGeocoder::GeocodingError => e
@@ -18,36 +18,45 @@ RSpec.describe GoogleMapsGeocoder do
           pending 'waiting for query limit to pass'
         end
 
-        it { should be_partial_match }
-        it { should_not be_exact_match }
+        it { is_expected.to be_partial_match }
+        it { is_expected.not_to be_exact_match }
 
         describe '#formatted_street_address' do
           it { expect(geocoder.formatted_street_address).to eq '1600 Pennsylvania Avenue Northwest' }
         end
+
         describe '#city' do
           it { expect(geocoder.city).to eq 'Washington' }
         end
+
         describe '#state_long_name' do
           it { expect(geocoder.state_long_name).to eq 'District of Columbia' }
         end
+
         describe '#state_short_name' do
           it { expect(geocoder.state_short_name).to eq 'DC' }
         end
+
         describe '#postal_code' do
           it { expect(geocoder.postal_code).to eq '20500' }
         end
+
         describe '#country_short_name' do
           it { expect(geocoder.country_short_name).to eq 'US' }
         end
+
         describe '#country_long_name' do
           it { expect(geocoder.country_long_name).to eq 'United States' }
         end
+
         describe '#formatted_address' do
           it { expect(geocoder.formatted_address).to match(/1600 Pennsylvania Avenue NW, Washington, DC 20500, USA/) }
         end
+
         describe '#lat' do
           it { expect(geocoder.lat).to be_within(0.005).of(38.8976633) }
         end
+
         describe '#lat' do
           it { expect(geocoder.lng).to be_within(0.005).of(-77.0365739) }
         end
@@ -56,24 +65,31 @@ RSpec.describe GoogleMapsGeocoder do
           describe '#address' do
             it { expect(geocoder.address).to eq subject.formatted_address }
           end
+
           describe '#coordinates' do
             it { expect(geocoder.coordinates).to eq [subject.lat, subject.lng] }
           end
+
           describe '#country' do
             it { expect(geocoder.country).to eq subject.country_long_name }
           end
+
           describe '#country_code' do
             it { expect(geocoder.country_code).to eq subject.country_short_name }
           end
+
           describe '#latitude' do
             it { expect(geocoder.latitude).to eq subject.lat }
           end
+
           describe '#longitude' do
             it { expect(geocoder.longitude).to eq subject.lng }
           end
+
           describe '#state' do
             it { expect(geocoder.state).to eq subject.state_long_name }
           end
+
           describe '#state_code' do
             it { expect(geocoder.state_code).to eq subject.state_short_name }
           end
@@ -82,17 +98,17 @@ RSpec.describe GoogleMapsGeocoder do
     end
 
     context 'when API key is invalid' do
+      subject(:geocoder) do
+        described_class.new('nowhere that comes to mind')
+      rescue SocketError
+        pending 'waiting for a network connection'
+      end
+
       around do |example|
-        original_key = ENV['GOOGLE_MAPS_API_KEY']
+        original_key = ENV.fetch('GOOGLE_MAPS_API_KEY', nil)
         ENV['GOOGLE_MAPS_API_KEY'] = 'invalid_key'
         example.run
         ENV['GOOGLE_MAPS_API_KEY'] = original_key
-      end
-
-      subject(:geocoder) do
-        GoogleMapsGeocoder.new('nowhere that comes to mind')
-      rescue SocketError
-        pending 'waiting for a network connection'
       end
 
       it { expect { geocoder }.to raise_error GoogleMapsGeocoder::GeocodingError }

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -7,6 +7,7 @@ require "#{File.dirname(__FILE__)}/../spec_helper"
 RSpec.describe GoogleMapsGeocoder do
   describe '#new' do
     context 'when API key is valid' do
+      # rubocop:disable RSpec/NestedGroups
       context 'with "White House"' do
         subject(:geocoder) do
           described_class.new('White House')
@@ -95,6 +96,7 @@ RSpec.describe GoogleMapsGeocoder do
           end
         end
       end
+      # rubocop:enable RSpec/NestedGroups
     end
 
     context 'when API key is invalid' do

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe GoogleMapsGeocoder do
           it { expect(geocoder.lat).to be_within(0.005).of(38.8976633) }
         end
 
-        describe '#lat' do
+        describe '#lng' do
           it { expect(geocoder.lng).to be_within(0.005).of(-77.0365739) }
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,12 +16,12 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'google_maps_geocoder/google_maps_geocoder'
 # silence output
 RSpec.configure do |config|
-  config.before(:example) do
+  config.before do
     quiet_logger = Logger.new(IO::NULL)
     allow(Logger).to receive(:new).and_return(quiet_logger)
   end
 
-  config.after(:example) do
+  config.after do
     allow(Logger).to receive(:new).and_call_original
   end
 end


### PR DESCRIPTION
# Closes: n/a

## Goal
Configure installed Rubocop extensions correctly and add `rubocop-performance`.

## Approach
1. Add `rubocop-performance` to `Gemfile`.
2. Add `rubocop.yml` and require all extensions.
3. Run `rubocop -A`.
4. Fix remaining warnings.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
