### PR TITLE
conf: remove old rubies, dependency versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Ruby ${{ matrix.ruby-version }}
     strategy:
       matrix:
-        ruby-version: ['3.0', 3.1, 3.2, 3.3]
+        ruby-version: [3.1, 3.2, 3.3]
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,13 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'inch', '~> 0.8'
-gem 'pry', '~> 0.14.1'
-gem 'rake', '~> 13'
-gem 'rspec', '~> 3'
-gem 'rubocop', '< 1.69'
+gem 'inch'
+gem 'pry'
+gem 'rake'
+gem 'rspec'
+gem 'rubocop'
 gem 'rubocop-performance', require: false
 gem 'rubocop-rake', require: false
 gem 'rubocop-rspec', require: false
-gem 'simplecov', '~> 0.18'
-gem 'simplecov-lcov', '~> 0.8'
+gem 'simplecov'
+gem 'simplecov-lcov'

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.email = 'rod@foveacentral.com'
   s.signing_key = File.expand_path('~/.ssh/gem-private_key.pem') if $PROGRAM_NAME.end_with?('gem')
 
-  s.add_dependency 'rack', '>= 2.1.4', '< 3.2.0'
+  s.add_dependency 'rack'
 
   s.files = `git ls-files`.split "\n"
   s.require_paths = ['lib']

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split "\n"
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 3'
+  s.required_ruby_version = '>= 3.1'
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split "\n"
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 3.0'
+  s.required_ruby_version = '~> 3'
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/google_maps_geocoder.gemspec
+++ b/google_maps_geocoder.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split "\n"
   s.require_paths = ['lib']
-  s.required_ruby_version = '~> 3'
+  s.required_ruby_version = '>= 3'
   s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
# Closes: n/a

## Goal
Increase security and compatibility and make the install process less brittle by:
* restricting Ruby to [supported versions](https://endoflife.date/ruby)
* *not* specifying dependency versions

This should also reduce Dependabot noise.

## Approach
1. Remove unmaintained 3.0 from `test.yml` and update `required_ruby_version`.
2. Remove versions from `Gemfile` and `gemspec`.
3. Delete `Gemfile.lock` and run `bundle install`.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
