### PR TITLE
f(x): GoogleMapsGeocoder.new accepts optional Logger

### DIFF
--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -75,7 +75,7 @@ class GoogleMapsGeocoder
     @json = address.is_a?(String) ? google_maps_response(address) : address
     status = @json && @json['status']
     raise RuntimeError if status == 'OVER_QUERY_LIMIT'
-    raise GeocodingError.new(@json, logger: logger) if !@json || @json.empty? || status != 'OK'
+    raise GeocodingError.new(@json, logger:) if !@json || @json.empty? || status != 'OK'
 
     set_attributes_from_json
     logger.info('GoogleMapsGeocoder') { "Geocoded \"#{address}\" => \"#{formatted_address}\"" }

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -71,7 +71,7 @@ class GoogleMapsGeocoder
   #   address
   # @example
   #   chez_barack = GoogleMapsGeocoder.new '1600 Pennsylvania DC'
-  def initialize(address, logger = Logger.new($stderr))
+  def initialize(address, logger: Logger.new($stderr))
     @json = address.is_a?(String) ? google_maps_response(address) : address
     status = @json && @json['status']
     raise RuntimeError if status == 'OVER_QUERY_LIMIT'

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -107,7 +107,7 @@ class GoogleMapsGeocoder
   end
 
   # A geocoding error returned by Google Maps.
-  class GeocodingError < StandardError
+  class GeocodingError < RuntimeError
     # Returns the complete JSON response from Google Maps as a Hash.
     #
     # @return [Hash] Google Maps' JSON response

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -66,7 +66,7 @@ class GoogleMapsGeocoder
   # object.
   #
   # @param address [String] a geocodable address
-  # @param logger [Logger] a standard Logger
+  # @param logger [Logger] a standard Logger, defaults to standard error
   # @return [GoogleMapsGeocoder] the Google Maps result for the specified
   #   address
   # @example

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -121,6 +121,7 @@ class GoogleMapsGeocoder
     # Initialize a GeocodingError wrapping the JSON returned by Google Maps.
     #
     # @param json [Hash] Google Maps' JSON response
+    # @param logger [Logger] a standard Logger
     # @return [GeocodingError] the geocoding error
     def initialize(json = {}, logger:)
       @json = json

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -66,20 +66,19 @@ class GoogleMapsGeocoder
   # object.
   #
   # @param address [String] a geocodable address
+  # @param logger [Logger] a standard Logger
   # @return [GoogleMapsGeocoder] the Google Maps result for the specified
   #   address
   # @example
   #   chez_barack = GoogleMapsGeocoder.new '1600 Pennsylvania DC'
-  def initialize(address)
+  def initialize(address, logger = Logger.new($stderr))
     @json = address.is_a?(String) ? google_maps_response(address) : address
     status = @json && @json['status']
     raise RuntimeError if status == 'OVER_QUERY_LIMIT'
     raise GeocodingError, @json if !@json || @json.empty? || status != 'OK'
 
     set_attributes_from_json
-    Logger.new($stderr).info('GoogleMapsGeocoder') do
-      "Geocoded \"#{address}\" => \"#{formatted_address}\""
-    end
+    logger.info('GoogleMapsGeocoder') { "Geocoded \"#{address}\" => \"#{formatted_address}\"" }
   end
 
   # Returns the address' coordinates as an array of floats.

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -125,7 +125,7 @@ class GoogleMapsGeocoder
     def initialize(json = {})
       @json = json
       if (message = @json['error_message'])
-        Logger.new($stderr).error(message)
+        Logger.new($stderr).error "GeocodingError.new: #{message}"
       end
       super(@json)
     end

--- a/lib/google_maps_geocoder/google_maps_geocoder.rb
+++ b/lib/google_maps_geocoder/google_maps_geocoder.rb
@@ -75,7 +75,7 @@ class GoogleMapsGeocoder
     @json = address.is_a?(String) ? google_maps_response(address) : address
     status = @json && @json['status']
     raise RuntimeError if status == 'OVER_QUERY_LIMIT'
-    raise GeocodingError, @json if !@json || @json.empty? || status != 'OK'
+    raise GeocodingError.new(@json, logger: logger) if !@json || @json.empty? || status != 'OK'
 
     set_attributes_from_json
     logger.info('GoogleMapsGeocoder') { "Geocoded \"#{address}\" => \"#{formatted_address}\"" }
@@ -122,10 +122,10 @@ class GoogleMapsGeocoder
     #
     # @param json [Hash] Google Maps' JSON response
     # @return [GeocodingError] the geocoding error
-    def initialize(json = {})
+    def initialize(json = {}, logger:)
       @json = json
       if (message = @json['error_message'])
-        Logger.new($stderr).error "GeocodingError.new: #{message}"
+        logger.error "GeocodingError.new: #{message}"
       end
       super(@json)
     end


### PR DESCRIPTION
# Closes: #138

## Goal
Expose the gem's logger so users can customize it.

## Approach
1. Change `GoogleMapsGeocoder.new` to accept an optional `Logger`.
2. Default 1 to standard error.
3. Subclass `GeocodingError` from the more specific `RuntimeError`.
4. Pass logger to 3.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
