### PR TITLE
CI: CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       olle.jonsson@gmail.com
+*       rod@foveacentral.com
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+# *.js    @octocat @github/js
+
+# You can also use email addresses if you prefer.
+# docs/*  docs@example.com

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       olle.jonsson@gmail.com
-*       rod@foveacentral.com
+*       @olleolleolle
+*       @ivanoblomov 
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners


### PR DESCRIPTION
# Re: #136

## Goal
Address https://github.com/FoveaCentral/google_maps_geocoder/security/code-scanning/1 by adding `CODEOWNERS` to the repo.

## Approach
1. Declare Olle and Rod as `CODEOWNERS` so their reviews will [automatically be requested](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) when relevant PRs are opened.

### Note
Notifications will be disabled as long as a PR is marked as "draft".

Signed-off-by: Roderick Monje <rod@foveacentral.com>
