### PR TITLE
fix: match failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,4 @@ Complete RDoc documentation is available at [RubyDoc.info](https://www.rubydoc.i
 
 ## [Contributing to GoogleMapsGeocoder](.github/CONTRIBUTING.md)
 
-## Copyright
-
-Copyright © 2011-2024 Roderick Monje. See [LICENSE.txt](LICENSE.txt) for further details.
+Copyright © 2011-2025 Roderick Monje. See [LICENSE.txt](LICENSE.txt) for further details.

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe GoogleMapsGeocoder do
           pending 'waiting for query limit to pass'
         end
 
-        it { is_expected.to be_partial_match }
-        it { is_expected.not_to be_exact_match }
+        it { is_expected.not_to be_partial_match }
+        it { is_expected.to be_exact_match }
 
         describe '#formatted_street_address' do
           it { expect(geocoder.formatted_street_address).to eq '1600 Pennsylvania Avenue Northwest' }

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe GoogleMapsGeocoder do
         end
 
         describe '#formatted_address' do
-          it { expect(geocoder.formatted_address).to match(/1600 Pennsylvania Avenue NW, Washington, DC 20500, USA/) }
+          it { expect(geocoder.formatted_address).to match(/1600 Pennsylvania Ave.+ NW, Washington, DC 20500, USA/) }
         end
 
         describe '#lat' do

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GoogleMapsGeocoder do
       # rubocop:disable RSpec/NestedGroups
       context 'with "White House"' do
         subject(:geocoder) do
-          described_class.new('White House')
+          described_class.new('1600 Pennsylvania Ave, Washington DC')
         rescue SocketError
           pending 'waiting for a network connection'
         rescue GoogleMapsGeocoder::GeocodingError => e

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe GoogleMapsGeocoder do
           pending 'waiting for query limit to pass'
         end
 
-        it { is_expected.not_to be_partial_match }
-        it { is_expected.to be_exact_match }
+        it { is_expected.to be_partial_match }
+        it { is_expected.not_to be_exact_match }
 
         describe '#formatted_street_address' do
           it { expect(geocoder.formatted_street_address).to eq '1600 Pennsylvania Avenue Northwest' }

--- a/spec/lib/google_maps_geocoder_spec.rb
+++ b/spec/lib/google_maps_geocoder_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe GoogleMapsGeocoder do
         end
 
         describe '#formatted_address' do
-          it { expect(geocoder.formatted_address).to match(/1600 Pennsylvania Ave.+ NW, Washington, DC 20500, USA/) }
+          it { expect(geocoder.formatted_address).to match(/1600 Pennsylvania Ave.* NW, Washington, DC 20500, USA/) }
         end
 
         describe '#lat' do


### PR DESCRIPTION
# Closes: n/a

## Goal
Fix the failures:
```ruby
Failures:

  1) GoogleMapsGeocoder#new when API key is valid with "White House" is expected to be partial match
     Failure/Error: it { is_expected.to be_partial_match }
       expected `#<GoogleMapsGeocoder:0x0000000104619d88 @json={"results"=>[{"address_components"=>[{"long_name"=>"160...enue NW, Washington, DC 20500, USA", @formatted_street_address="1600 Pennsylvania Avenue Northwest">.partial_match?` to be truthy, got false
     # ./spec/lib/google_maps_geocoder_spec.rb:22:in `block (5 levels) in <top (required)>'

  2) GoogleMapsGeocoder#new when API key is valid with "White House" is expected not to be exact match
     Failure/Error: it { is_expected.not_to be_exact_match }
       expected `#<GoogleMapsGeocoder:0x000000010848c110 @json={"results"=>[{"address_components"=>[{"long_name"=>"160...enue NW, Washington, DC 20500, USA", @formatted_street_address="1600 Pennsylvania Avenue Northwest">.exact_match?` to be falsey, got true
     # ./spec/lib/google_maps_geocoder_spec.rb:23:in `block (5 levels) in <top (required)>'

Finished in 3.18 seconds (files took 0.22168 seconds to load)
21 examples, 2 failures

Failed examples:

rspec ./spec/lib/google_maps_geocoder_spec.rb:22 # GoogleMapsGeocoder#new when API key is valid with "White House" is expected to be partial match
rspec ./spec/lib/google_maps_geocoder_spec.rb:23 # GoogleMapsGeocoder#new when API key is valid with "White House" is expected not to be exact match
```

## Approach
1. Reverse the assertions (since the failing method returns a boolean).
2. Specify White House's explicit address (to insure an exact match).
3. Allow for "Ave" or "Avenue".
4. (Update copyright.)

## Notes
Google apparently changed the meaning of `partial_match` for Geocoder results though neither the [release notes](https://developers.google.com/maps/documentation/geocoding/release-notes) or [API docs](https://developers.google.com/maps/documentation/geocoding/requests-geocoding#results) indicate this.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
