### PR TITLE
CI: pin qlty-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     - run: bundle exec rake
       env:
         GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
-    - uses: qltysh/qlty-action/coverage@v1
+    - uses: qltysh/qlty-action/coverage@b9133a486505563742d768da29f7951271678c87
       with:
         oidc: true
         files: coverage/lcov.info


### PR DESCRIPTION
# Closes: n/a

## Goal
Fix [Scorecard's](https://scorecard.dev/viewer/?uri=github.com/FoveaCentral/google_maps_geocoder) Pinned-Dependencies warning:

> Warn: third-party GitHubAction not pinned by hash: .github/workflows/test.yml:24: update your workflow using https://app.stepsecurity.io/secureworkflow/FoveaCentral/google_maps_geocoder/test.yml/master?enable=pin

## Approach
1. Replace tag with SHA.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
